### PR TITLE
Add build dir back to gitignore, with exceptions

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,3 +12,6 @@ debug.out
 coverage/
 config.json
 npm-debug.log
+build
+!build/build.go
+!build/README.md


### PR DESCRIPTION
There's a command in the makefile for creating a tar of the binary based on the tagged version, which is what the build/build.go script does. That script builds these things into the build directory, so we should ignore those build artifacts. But the build.go and README.md in there should stay in the repo.
