### PR TITLE
Custom binIDs [WIP: Needs some frontend work still]

### DIFF
--- a/geobinserver_test.go
+++ b/geobinserver_test.go
@@ -217,7 +217,7 @@ func TestBinHandler200(t *testing.T) {
 	assertResponseOK(w, t)
 }
 
-func TestBinHistoryReturnsErrorForInvalidBin(t *testing.T) {
+func TestBinHistoryCreatesNonExistantBin(t *testing.T) {
 	binId := "neverland"
 
 	// Check history for our bin
@@ -229,7 +229,7 @@ func TestBinHistoryReturnsErrorForInvalidBin(t *testing.T) {
 	w := httptest.NewRecorder()
 	createGeobinServer().ServeHTTP(w, req)
 
-	assertResponseCode(w, http.StatusNotFound, t)
+	assertResponseOK(w, t)
 }
 
 func TestBinHistoryWorksAsIntended(t *testing.T) {

--- a/geobinserver_test.go
+++ b/geobinserver_test.go
@@ -148,16 +148,15 @@ func TestCreateHandler(t *testing.T) {
 	assertBodyContainsKey(w.Body, "expires", t)
 }
 
-func TestBinHandler404(t *testing.T) {
-	// Test 404 for nonexistant bin
-	req, err := http.NewRequest("POST", "http://testing.geobin.io/nonexistant_bin", nil)
+func TestCustomBinHandler(t *testing.T) {
+	req, err := http.NewRequest("POST", "http://testing.geobin.io/my_awesome_bin_id", nil)
 	if err != nil {
 		t.Error(err)
 	}
 	w := httptest.NewRecorder()
 	createGeobinServer().ServeHTTP(w, req)
 
-	assertResponseNotFound(w, t)
+	assertResponseOK(w, t)
 }
 
 func TestBinHandlerEmptyBody(t *testing.T) {

--- a/handlers.go
+++ b/handlers.go
@@ -123,9 +123,10 @@ func (gb *geobinServer) binHandler(w http.ResponseWriter, r *http.Request) {
 	}
 
 	if !exists {
-		// TODO: Create bin.
-		http.NotFound(w, r)
-		return
+		// create it
+		if _, err = gb.createBin(name, w); err != nil {
+			return
+		}
 	}
 
 	var body []byte

--- a/static/app/bin/binList.html
+++ b/static/app/bin/binList.html
@@ -46,8 +46,8 @@
 
 <div class="panel" ng-if="validBin && isEmpty(history)">
   <div class="panel-heading">
-    <h4>No History Yet</h4>
-    <p>Try sending a request!</p>
+    <h4>No History</h4>
+    <p>This bin is empty. Try sending a request!</p>
   </div>
 
   <ul class="list-group">
@@ -63,12 +63,12 @@
 
 <div class="alert alert-info" ng-if="!validBin">
   <h4><i class="fa fa-warning"></i> Geobin "{{binId}}" Not Found!</h4>
-  <p>Either this bin has expired, or it never existed! Either way there's nothing to see here. You can either go back home or create a new geobin.</p>
+  <p>This is an invalid bin name! You can either go back home or create a new geobin.</p>
   <hr>
   <p>
     <button type="button" class="btn btn-primary"
       analytics-on="click"
-      analytics-event="Create Geobin (expired)"
+      analytics-event="Create Geobin (invalid)"
       ng-click="create()"><i class="fa fa-magic"></i> Create a New Geobin</button>
     <a href="/" class="btn btn-link"><i class="fa fa-home"></i> Go Back Home</a>
   </p>

--- a/static/app/home/home.html
+++ b/static/app/home/home.html
@@ -1,7 +1,7 @@
 <div class="topic">
   <div class="container">
     <h1>Geobin</h1>
-    <p>Inspect HTTP Requests with Geographic Data</p>
+    <p>Visualize HTTP Requests with Geographic Data</p>
   </div>
 </div>
 
@@ -17,6 +17,30 @@
           <p>Geobin allows you to create a temporary URL to collect and inspect JSON requests that contain geographic data. Inspect the headers and body of a request and view any geographic data parsed out of the body on a map.</p>
           <p>You can also receive data in real time. As long as your browser supports <a href="http://caniuse.com/websockets">WebSockets</a>, once you're looking at a geobin, new data will be streamed directly to the browser and any found geographic data will be mapped instantly.</p>
           Hat tip to <a href="http://requestb.in">RequestBin</a> for inspiration.
+        </div>
+      </div>
+
+      <div class="panel panel-default">
+        <div class="panel-heading">
+          <h2 class="panel-title">How do I use it?</h2>
+        </div>
+        <div class="panel-body">
+        
+            <p>You can create a new temporary bin by clicking the "<a href="" analytics-on="click" analytics-event="Create Geobin" ng-click="create()">Create a New Geobin</a>" button above to get
+                a new randomly generated Bin ID, or you can use an arbitrary custom Bin ID of your choosing.</p>
+
+            <p>To verify that your custom ID valid and is not currently being used by someone else go put the ID in after the slash:
+                <a href="http://{{host}}/my_custom_bin_id">http://{{host}}/my_custom_bin_id</a>.</p>
+
+            <p>After you have a URL, post some data to it! We currently only accept JSON formatted data in the body of HTTP POST requests.</p>
+
+            <p>Anything you post to geobin will expire after 48 hours. The history list to the right shows the Geobins you've viewed recently and the amount
+                of time until their last piece of data will expire.</p>
+
+            <p>It is also worth noting that Geobin is built to be a tool for quickly visualizing data in a temporary fashion. Its primary
+                purpose is to be a debugging tool. As such, there is no access control for the bins. Anyone with the URL can POST to or view
+                the data in the bin. Given that, it is a good idea to avoid using a custom bin ID that has a high probability of a clash with
+                others. Please keep this in mind when posting data to a bin, <strong>it is not secured or protected in any fashion</strong>.</p>
         </div>
       </div>
 

--- a/static/app/home/homeCtrl.js
+++ b/static/app/home/homeCtrl.js
@@ -2,6 +2,7 @@ angular.module('Geobin.controllers')
 .controller('HomeCtrl', ['$scope', 'api', 'store',
   function ($scope, api, store) {
     document.title = 'Geobin';
+    $scope.host = window.location.host;
     $scope.create = api.create;
     $scope.bins = store.local.session.history;
     $scope.enabled = store.local.enabled;


### PR DESCRIPTION
Changes to support custom bin IDs for #82. Also makes changes that effectively implement the activity refreshing the expiration (#101) as any request to a bin that doesn't exist will create said bin instead of 404ing. We'll need to talk more about whether or not the data should actually persist more than 48 hours based on activity. 