### PR TITLE
some work towards finishing & shipping custom bin IDs

### DIFF
--- a/config.go
+++ b/config.go
@@ -4,13 +4,12 @@ import (
 	"encoding/json"
 	"log"
 	"os"
+	"time"
 )
 
 const (
 	// Path to the config file
 	configFile = "./config.json"
-	// Requests per second
-	rateLimit = 1
 )
 
 // Config holds configuration values read in from the config file
@@ -23,6 +22,7 @@ type Config struct {
 	NameVals   string
 	NameLength int
 	RateLimit  int
+	BinExpires time.Duration
 }
 
 // loadConfig reads configuration values from the config file
@@ -39,6 +39,7 @@ func loadConfig() *Config {
 		log.Fatal(err)
 	}
 
-	conf.RateLimit = rateLimit
+	conf.BinExpires = conf.BinExpires * time.Hour
+
 	return &conf
 }

--- a/config.json.dist
+++ b/config.json.dist
@@ -5,5 +5,7 @@
   "RedisPass": "",
   "RedisDB": 0,
   "NameVals": "023456789abcdefghjkmnopqrstuvwxyzABCDEFGHJKMNOPQRSTUVWXYZ",
-  "NameLength": 10
+  "NameLength": 10,
+  "RateLimit": 1,
+  "BinExpires": 48
 }

--- a/geobin.go
+++ b/geobin.go
@@ -9,7 +9,7 @@ import (
 	"net/http"
 	"runtime"
 
-	"github.com/go-redis/redis"
+	redis "gopkg.in/redis.v1"
 )
 
 // some read-only global vars

--- a/geobinserver_test.go
+++ b/geobinserver_test.go
@@ -15,7 +15,7 @@ import (
 	"time"
 
 	"github.com/bmizerany/assert"
-	"github.com/go-redis/redis"
+	redis "gopkg.in/redis.v1"
 )
 
 var testConf = &Config{

--- a/geobinserver_test.go
+++ b/geobinserver_test.go
@@ -27,6 +27,7 @@ var testConf = &Config{
 	"023456789abcdefghjkmnopqrstuvwxyzABCDEFGHJKMNOPQRSTUVWXYZ",
 	10,
 	999,
+	48 * time.Hour,
 }
 
 type MockRedis struct {

--- a/handlers.go
+++ b/handlers.go
@@ -25,14 +25,22 @@ func (gb *geobinServer) createBin(n string, w http.ResponseWriter) (time.Time, e
 	}
 
 	// Set expiration
-	d := 48 * time.Hour
-	if _, err = gb.Expire(n, d); err != nil {
-		log.Println("Failure to set EXPIRE for", n, err)
+	d := gb.conf.BinExpires
+	if err = gb.setBinExpires(n, d); err != nil {
 		http.Error(w, "Could not generate new Geobin!", http.StatusInternalServerError)
 		return t, err
 	}
 
 	return t.Add(d), nil
+}
+
+// setBinExpires sets the redis EXPIRE key for the given bin id.
+func (gb *geobinServer) setBinExpires(n string, d time.Duration) error {
+	if _, err := gb.Expire(n, d); err != nil {
+		log.Println("Failure to set EXPIRE for", n, err)
+		return err
+	}
+	return nil
 }
 
 // createHandler handles requests to /api/1/create. It creates a randomly generated bin_id,
@@ -156,6 +164,9 @@ func (gb *geobinServer) binHandler(w http.ResponseWriter, r *http.Request) {
 	if _, err = gb.ZAdd(name, redis.Z{Score: float64(time.Now().UTC().Unix()), Member: string(encoded)}); err != nil {
 		log.Println("Failure to ZADD to", name, err)
 	}
+
+	// reset the bin expiry time to 48 hours from now
+	gb.setBinExpires(name, gb.conf.BinExpires)
 
 	if _, err = gb.Publish(name, string(encoded)); err != nil {
 		log.Println("Failure to PUBLISH to", name, err)

--- a/handlers.go
+++ b/handlers.go
@@ -9,8 +9,8 @@ import (
 	"strings"
 	"time"
 
-	"github.com/go-redis/redis"
 	"github.com/nu7hatch/gouuid"
+	redis "gopkg.in/redis.v1"
 )
 
 func (gb *geobinServer) createBin(n string, w http.ResponseWriter) (time.Time, error) {

--- a/rediswrapper.go
+++ b/rediswrapper.go
@@ -3,7 +3,7 @@ package main
 import (
 	"time"
 
-	"github.com/go-redis/redis"
+	redis "gopkg.in/redis.v1"
 )
 
 // mock our use of redis pubsub for modularity/testing purposes


### PR DESCRIPTION
* Sanity-checked changes in https://github.com/geobin-io/geobin.io/pull/115 that enabled custom bins: :ok_hand: 

* The changes to `binHandler` extend the expiration of a bin by 48 hours whenever a POST comes in. This was the easiest way to extend the life of active bins, since redis doesn't support setting expire times on set members.

